### PR TITLE
Breaking change - top level API - log levels

### DIFF
--- a/config.go
+++ b/config.go
@@ -59,6 +59,6 @@ func WithConfigChanges(mods ...ConfigModifier) SeedModifier {
 	}
 }
 
-func (log *Log) Config() Config {
-	return log.span.seed.config
+func (logger *Logger) Config() Config {
+	return logger.span.seed.config
 }

--- a/context_test.go
+++ b/context_test.go
@@ -52,7 +52,7 @@ func TestCustomFromContext(t *testing.T) {
 	defer customLog.Done()
 	assert.NotEqual(t, Default, customLog, "logs are not equal")
 	assert.NotEqual(t, Default.Settings(), customLog.Settings(), "default settings")
-	assert.Equal(t, noFilenameFunc(Default.Sub().PrefillText("banana").Log().Settings()), noFilenameFunc(customLog.Settings()), "modified settings")
+	assert.Equal(t, noFilenameFunc(Default.Sub().PrefillText("banana").Logger().Settings()), noFilenameFunc(customLog.Settings()), "modified settings")
 }
 
 func noFilenameFunc(settings LogSettings) LogSettings {

--- a/internal/enumer_test.zzzgo
+++ b/internal/enumer_test.zzzgo
@@ -3,9 +3,8 @@ package internal_test
 import (
 	"encoding/json"
 	"strconv"
+	"strings"
 	"testing"
-
-	"github.com/xoplog/xop-go/xopbase"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/line.go
+++ b/line.go
@@ -27,11 +27,11 @@ func (line *Line) Any(k string, v interface{}) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactAny != nil {
-		line.log.settings.redactAny(line.line, k, v, !line.log.span.referencesKept)
+	if line.logger.settings.redactAny != nil {
+		line.logger.settings.redactAny(line.line, k, v, !line.logger.span.referencesKept)
 		return line
 	}
-	if line.log.span.referencesKept {
+	if line.logger.span.referencesKept {
 		// TODO: make copy function configurable
 		v = deepcopy.Copy(v)
 	}
@@ -67,8 +67,8 @@ func (line *Line) Error(k string, v error) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactError != nil {
-		line.log.settings.redactError(line.line, k, v)
+	if line.logger.settings.redactError != nil {
+		line.logger.settings.redactError(line.line, k, v)
 		return line
 	}
 	line.line.String(k, v.Error(), xopbase.ErrorDataType)
@@ -82,8 +82,8 @@ func (line *Line) Stringer(k string, v fmt.Stringer) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactString != nil {
-		line.log.settings.redactString(line.line, k, v.String())
+	if line.logger.settings.redactString != nil {
+		line.logger.settings.redactString(line.line, k, v.String())
 		return line
 	}
 	line.line.String(k, v.String(), xopbase.StringerDataType)
@@ -97,8 +97,8 @@ func (line *Line) String(k string, v string) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactString != nil {
-		line.log.settings.redactString(line.line, k, v)
+	if line.logger.settings.redactString != nil {
+		line.logger.settings.redactString(line.line, k, v)
 		return line
 	}
 	line.line.String(k, v, xopbase.StringDataType)

--- a/line.zzzgo
+++ b/line.zzzgo
@@ -22,11 +22,11 @@ func (line *Line) Any(k string, v interface{}) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactAny != nil {
-		line.log.settings.redactAny(line.line, k, v, !line.log.span.referencesKept)
+	if line.logger.settings.redactAny != nil {
+		line.logger.settings.redactAny(line.line, k, v, !line.logger.span.referencesKept)
 		return line
 	}
-	if line.log.span.referencesKept {
+	if line.logger.span.referencesKept {
 		// TODO: make copy function configurable
 		v = deepcopy.Copy(v)
 	}
@@ -62,8 +62,8 @@ func (line *Line) Error(k string, v error) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactError != nil {
-		line.log.settings.redactError(line.line, k, v)
+	if line.logger.settings.redactError != nil {
+		line.logger.settings.redactError(line.line, k, v)
 		return line
 	}
 	line.line.String(k, v.Error(), xopbase.ErrorDataType)
@@ -77,8 +77,8 @@ func (line *Line) Stringer(k string, v fmt.Stringer) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactString != nil {
-		line.log.settings.redactString(line.line, k, v.String())
+	if line.logger.settings.redactString != nil {
+		line.logger.settings.redactString(line.line, k, v.String())
 		return line
 	}
 	line.line.String(k, v.String(), xopbase.StringerDataType)
@@ -92,8 +92,8 @@ func (line *Line) String(k string, v string) *Line {
 	if line.skip {
 		return line
 	}
-	if line.log.settings.redactString != nil {
-		line.log.settings.redactString(line.line, k, v)
+	if line.logger.settings.redactString != nil {
+		line.logger.settings.redactString(line.line, k, v)
 		return line
 	}
 	line.line.String(k, v, xopbase.StringDataType)

--- a/seed.go
+++ b/seed.go
@@ -14,16 +14,16 @@ import (
 	"github.com/xoplog/xop-go/xoptrace"
 )
 
-// Seed is used to create a Log. Seed contains
+// Seed is used to create a Logger. Seed contains
 // the context of the log (trace parent, current trace, etc);
 // the set of base loggers to use;
 // and log settings (like minimum log level).
 //
 // Seed is used to bridge between parent logs and their
-// sub-spans. The functions that turn Seeds into Logs are:
-// Request(), which is used when the new Log is a "request"
+// sub-spans. The functions that turn Seeds into Loggers are:
+// Request(), which is used when the new logger is a "request"
 // which is a top-level indexed span; and
-// SubSpan(), which is used when the new Log is just a
+// SubSpan(), which is used when the new logger is just a
 // component of a parent Request().
 //
 // Use Request() for incoming requests from other servers and
@@ -60,7 +60,7 @@ func (seed Seed) Copy(mods ...SeedModifier) Seed {
 func (span *Span) SubSeed(mods ...SeedModifier) Seed {
 	n := Seed{
 		spanSeed: span.seed.copy(false),
-		settings: span.log.settings.Copy(),
+		settings: span.logger.settings.Copy(),
 	}
 	n.traceBundle.Parent = n.traceBundle.Trace
 	if !span.seed.spanSet {
@@ -167,7 +167,7 @@ func (seed Seed) applyMods(mods []SeedModifier) Seed {
 // Request creates a new top-level span (a request).  Use when
 // starting something new, like receiving an http request or
 // starting a cron job.
-func (seed Seed) Request(descriptionOrName string) *Log {
+func (seed Seed) Request(descriptionOrName string) *Logger {
 	now := time.Now()
 	seed = seed.react(true, descriptionOrName, now)
 	return seed.request(descriptionOrName, now)
@@ -177,7 +177,7 @@ func (seed Seed) Request(descriptionOrName string) *Log {
 // initializes the span/trace data as if it were a subspan.
 // The traceID must already be set.  Use this with caution,
 // it is meant for handing off from spans created elsewhere.
-func (seed Seed) SubSpan(descriptionOrName string) *Log {
+func (seed Seed) SubSpan(descriptionOrName string) *Logger {
 	now := time.Now()
 	seed = seed.react(false, descriptionOrName, now)
 	return seed.request(descriptionOrName, now)

--- a/seed.zzzgo
+++ b/seed.zzzgo
@@ -12,16 +12,16 @@ import (
 	"github.com/xoplog/xop-go/xoptrace"
 )
 
-// Seed is used to create a Log. Seed contains
+// Seed is used to create a Logger. Seed contains
 // the context of the log (trace parent, current trace, etc);
 // the set of base loggers to use;
 // and log settings (like minimum log level).
 //
 // Seed is used to bridge between parent logs and their
-// sub-spans. The functions that turn Seeds into Logs are:
-// Request(), which is used when the new Log is a "request"
+// sub-spans. The functions that turn Seeds into Loggers are:
+// Request(), which is used when the new logger is a "request"
 // which is a top-level indexed span; and
-// SubSpan(), which is used when the new Log is just a
+// SubSpan(), which is used when the new logger is just a
 // component of a parent Request().
 //
 // Use Request() for incoming requests from other servers and
@@ -58,7 +58,7 @@ func (seed Seed) Copy(mods ...SeedModifier) Seed {
 func (span *Span) SubSeed(mods ...SeedModifier) Seed {
 	n := Seed{
 		spanSeed: span.seed.copy(false),
-		settings: span.log.settings.Copy(),
+		settings: span.logger.settings.Copy(),
 	}
 	n.traceBundle.Parent = n.traceBundle.Trace
 	if !span.seed.spanSet {
@@ -165,7 +165,7 @@ func (seed Seed) applyMods(mods []SeedModifier) Seed {
 // Request creates a new top-level span (a request).  Use when
 // starting something new, like receiving an http request or
 // starting a cron job.
-func (seed Seed) Request(descriptionOrName string) *Log {
+func (seed Seed) Request(descriptionOrName string) *Logger {
 	now := time.Now()
 	seed = seed.react(true, descriptionOrName, now)
 	return seed.request(descriptionOrName, now)
@@ -175,7 +175,7 @@ func (seed Seed) Request(descriptionOrName string) *Log {
 // initializes the span/trace data as if it were a subspan.
 // The traceID must already be set.  Use this with caution,
 // it is meant for handing off from spans created elsewhere.
-func (seed Seed) SubSpan(descriptionOrName string) *Log {
+func (seed Seed) SubSpan(descriptionOrName string) *Logger {
 	now := time.Now()
 	seed = seed.react(false, descriptionOrName, now)
 	return seed.request(descriptionOrName, now)

--- a/span.go
+++ b/span.go
@@ -14,14 +14,14 @@ import (
 
 // Request provides access to the span that describes the overall
 // request. Metadata may be added at the request level.
-func (log *Log) Request() *Span {
-	return log.request.capSpan
+func (logger *Logger) Request() *Span {
+	return logger.request.capSpan
 }
 
 // Request provides access to the current span
 // Metadata may be added at the span level.
-func (log *Log) Span() *Span {
-	return log.capSpan
+func (logger *Logger) Span() *Span {
+	return logger.capSpan
 }
 
 func (span *Span) TraceState() xoptrace.State     { return span.seed.traceBundle.State }
@@ -31,7 +31,7 @@ func (span *Span) Trace() xoptrace.Trace          { return span.seed.traceBundle
 func (span *Span) Bundle() xoptrace.Bundle        { return span.seed.traceBundle.Copy() }
 
 func (span *Span) eft() *Span {
-	span.log.hasActivity(true)
+	span.logger.hasActivity(true)
 	return span
 }
 
@@ -77,7 +77,7 @@ func (span *Span) AnyImmutable(k *xopat.AnyAttribute, v interface{}) *Span {
 // on the base logger being used.
 // The return value does not need to be used.
 func (span *Span) Any(k *xopat.AnyAttribute, v interface{}) *Span {
-	if span.log.span.referencesKept {
+	if span.logger.span.referencesKept {
 		v = deepcopy.Copy(v)
 	}
 	span.base.MetadataAny(k, xopbase.ModelArg{

--- a/span.zzzgo
+++ b/span.zzzgo
@@ -10,14 +10,14 @@ import (
 
 // Request provides access to the span that describes the overall
 // request. Metadata may be added at the request level.
-func (log *Log) Request() *Span {
-	return log.request.capSpan
+func (logger *Logger) Request() *Span {
+	return logger.request.capSpan
 }
 
 // Request provides access to the current span
 // Metadata may be added at the span level.
-func (log *Log) Span() *Span {
-	return log.capSpan
+func (logger *Logger) Span() *Span {
+	return logger.capSpan
 }
 
 func (span *Span) TraceState() xoptrace.State     { return span.seed.traceBundle.State }
@@ -27,7 +27,7 @@ func (span *Span) Trace() xoptrace.Trace          { return span.seed.traceBundle
 func (span *Span) Bundle() xoptrace.Bundle        { return span.seed.traceBundle.Copy() }
 
 func (span *Span) eft() *Span {
-	span.log.hasActivity(true)
+	span.logger.hasActivity(true)
 	return span
 }
 
@@ -73,7 +73,7 @@ func (span *Span) AnyImmutable(k *xopat.AnyAttribute, v interface{}) *Span {
 // on the base logger being used.
 // The return value does not need to be used.
 func (span *Span) Any(k *xopat.AnyAttribute, v interface{}) *Span {
-	if span.log.span.referencesKept {
+	if span.logger.span.referencesKept {
 		v = deepcopy.Copy(v)
 	}
 	span.base.MetadataAny(k, xopbase.ModelArg{

--- a/sub.zzzgo
+++ b/sub.zzzgo
@@ -14,15 +14,15 @@ import (
 type Sub struct {
 	detached bool
 	settings LogSettings
-	log      *Log
+	logger   *Logger
 }
 
 // Detaching is a ephemeral type used in the chain
 //
-//	child := log.Sub().Detach().Fork()
-//	child := log.Sub().Detach().Step()
+//	child := logger.Sub().Detach().Fork()
+//	child := logger.Sub().Detach().Step()
 //
-// to indicate that the new log/span has an independent lifetime
+// to indicate that the new logger/span has an independent lifetime
 // from it's parent so a call to Done() on the parent does not imply
 // the child is done.
 type Detaching struct {
@@ -125,26 +125,26 @@ func (settings LogSettings) Copy() LogSettings {
 	return settings
 }
 
-func (log *Log) Settings() LogSettings {
-	return log.settings.Copy()
+func (logger *Logger) Settings() LogSettings {
+	return logger.settings.Copy()
 }
 
-// Sub is a first step in creating a sub-Log from the current log.
+// Sub is a first step in creating a sub-Log from the current logger.
 // Sub allows log settings to be modified.  The returned value must
-// be used.  It is used by a call to sub.Log(), sub.Fork(), or
+// be used.  It is used by a call to sub.Logger(), sub.Fork(), or
 // sub.Step().
 //
 // Logs created from Sub() are done when their parent is done.
-func (log *Log) Sub() *Sub {
+func (logger *Logger) Sub() *Sub {
 	return &Sub{
-		settings: log.settings.Copy(),
-		log:      log,
+		settings: logger.settings.Copy(),
+		logger:   logger,
 	}
 }
 
-// Detach followed by Fork() or Step() creates a sub-span/log that is detached from
+// Detach followed by Fork() or Step() creates a sub-span/logger that is detached from
 // it's parent.  A Done() on the parent does not imply Done() on the detached
-// log.
+// logger.
 func (sub Sub) Detach() *Detaching {
 	sub.detached = true
 	return &Detaching{
@@ -152,31 +152,31 @@ func (sub Sub) Detach() *Detaching {
 	}
 }
 
-func (d *Detaching) Step(msg string, mods ...SeedModifier) *Log { return d.sub.Step(msg, mods...) }
-func (d *Detaching) Fork(msg string, mods ...SeedModifier) *Log { return d.sub.Fork(msg, mods...) }
+func (d *Detaching) Step(msg string, mods ...SeedModifier) *Logger { return d.sub.Step(msg, mods...) }
+func (d *Detaching) Fork(msg string, mods ...SeedModifier) *Logger { return d.sub.Fork(msg, mods...) }
 
-// Fork creates a new Log that does not need to be terminated because
-// it is assumed to be done with the current log is finished.  The new log
+// Fork creates a new logger that does not need to be terminated because
+// it is assumed to be done with the current logger is finished.  The new logger
 // has its own span.
-func (sub *Sub) Fork(msg string, mods ...SeedModifier) *Log {
-	seed := sub.log.capSpan.SubSeed(mods...)
-	counter := int(atomic.AddInt32(&sub.log.span.forkCounter, 1))
+func (sub *Sub) Fork(msg string, mods ...SeedModifier) *Logger {
+	seed := sub.logger.capSpan.SubSeed(mods...)
+	counter := int(atomic.AddInt32(&sub.logger.span.forkCounter, 1))
 	seed.spanSequenceCode += "." + base26(counter-1)
 	seed.settings = sub.settings
-	return sub.log.newChildLog(seed, msg, sub.detached)
+	return sub.logger.newChildLog(seed, msg, sub.detached)
 }
 
-// Step creates a new log that does not need to be terminated -- it
-// represents the continued execution of the current log but doing
+// Step creates a new logger that does not need to be terminated -- it
+// represents the continued execution of the current logger but doing
 // something that is different and should be in a fresh span. The expectation
-// is that there is a parent log that is creating various sub-logs using
+// is that there is a parent logger that is creating various sub-logs using
 // Step over and over as it does different things.
-func (sub *Sub) Step(msg string, mods ...SeedModifier) *Log {
-	seed := sub.log.capSpan.SubSeed(mods...)
-	counter := int(atomic.AddInt32(&sub.log.span.stepCounter, 1))
+func (sub *Sub) Step(msg string, mods ...SeedModifier) *Logger {
+	seed := sub.logger.capSpan.SubSeed(mods...)
+	counter := int(atomic.AddInt32(&sub.logger.span.stepCounter, 1))
 	seed.spanSequenceCode += "." + strconv.Itoa(counter)
 	seed.settings = sub.settings
-	return sub.log.newChildLog(seed, msg, sub.detached)
+	return sub.logger.newChildLog(seed, msg, sub.detached)
 }
 
 // StackFrames sets the number of stack frames to include at
@@ -293,25 +293,25 @@ func (settings *LogSettings) NoPrefill() {
 	settings.prefillMsg = ""
 }
 
-func (log *Log) sendPrefill() {
-	if log.settings.prefillData == nil && log.settings.prefillMsg == "" && !log.settings.tagLinesWithSpanSequence {
-		log.prefilled = log.span.base.NoPrefill()
+func (logger *Logger) sendPrefill() {
+	if logger.settings.prefillData == nil && logger.settings.prefillMsg == "" && !logger.settings.tagLinesWithSpanSequence {
+		logger.prefilled = logger.span.base.NoPrefill()
 		return
 	}
-	prefilling := log.span.base.StartPrefill()
-	for _, f := range log.settings.prefillData {
+	prefilling := logger.span.base.StartPrefill()
+	for _, f := range logger.settings.prefillData {
 		f(prefilling)
 	}
-	if log.settings.tagLinesWithSpanSequence {
-		prefilling.String(xopconst.SpanSequenceCode.Key(), log.span.seed.spanSequenceCode, xopbase.StringDataType)
+	if logger.settings.tagLinesWithSpanSequence {
+		prefilling.String(xopconst.SpanSequenceCode.Key(), logger.span.seed.spanSequenceCode, xopbase.StringDataType)
 	}
-	log.prefilled = prefilling.PrefillComplete(log.settings.prefillMsg)
+	logger.prefilled = prefilling.PrefillComplete(logger.settings.prefillMsg)
 }
 
 // PrefillEmbeddedEnum is used to set a data element that is included on every log
 // line.
 // PrefillEmbeddedEnum is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillEmbeddedEnum(k xopat.EmbeddedEnum) *Sub {
 	sub.settings.PrefillEmbeddedEnum(k)
 	return sub
@@ -325,7 +325,7 @@ func (settings *LogSettings) PrefillEmbeddedEnum(k xopat.EmbeddedEnum) {
 // PrefillEnum is used to set a data element that is included on every log
 // line.
 // PrefillEnum is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillEnum(k *xopat.EnumAttribute, v xopat.Enum) *Sub {
 	sub.settings.PrefillEnum(k, v)
 	return sub
@@ -357,7 +357,7 @@ func (settings *LogSettings) PrefillError(k string, v error) {
 // line.  Values provided with PrefillAny will be copied
 // using https://github.com/mohae/deepcopy 's Copy().
 // PrefillAny is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 // Redaction is not supported.
 func (sub *Sub) PrefillAny(k string, v interface{}) *Sub {
 	sub.settings.PrefillAny(k, v)
@@ -368,7 +368,7 @@ func (sub *Sub) PrefillAny(k string, v interface{}) *Sub {
 // line.  Values provided with PrefillAny will be copied
 // using https://github.com/mohae/deepcopy 's Copy().
 // PrefillAny is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 // Redaction is not supported.
 func (settings *LogSettings) PrefillAny(k string, v interface{}) {
 	settings.prefillData = append(settings.prefillData, func(line xopbase.Prefilling) {
@@ -379,7 +379,7 @@ func (settings *LogSettings) PrefillAny(k string, v interface{}) {
 // PrefillFloat32 is used to set a data element that is included on every log
 // line.
 // PrefillFloat32 is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillFloat32(k string, v float32) *Sub {
 	sub.settings.PrefillFloat32(k, v)
 	return sub
@@ -394,8 +394,7 @@ func (settings *LogSettings) PrefillFloat32(k string, v float32) {
 // PrefillZZZ is used to set a data element that is included on every log
 // line.
 // PrefillZZZ is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
-// END CONDITIONAL
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillZZZ(k string, v zzz) *Sub {
 	sub.settings.PrefillZZZ(k, v)
 	return sub
@@ -410,7 +409,7 @@ func (settings *LogSettings) PrefillZZZ(k string, v zzz) {
 // PrefillZZZ is used to set a data element that is included on every log
 // line.
 // PrefillZZZ is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillZZZ(k string, v zzz) *Sub {
 	sub.settings.PrefillZZZ(k, v)
 	return sub
@@ -425,7 +424,7 @@ func (settings *LogSettings) PrefillZZZ(k string, v zzz) {
 // PrefillZZZ is used to set a data element that is included on every log
 // line.
 // PrefillZZZ is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillZZZ(k string, v zzz) *Sub {
 	sub.settings.PrefillZZZ(k, v)
 	return sub
@@ -440,7 +439,7 @@ func (settings *LogSettings) PrefillZZZ(k string, v zzz) {
 // PrefillZZZ is used to set a data element that is included on every log
 // line.
 // PrefillZZZ is not threadsafe with respect to other calls on the same *Sub.
-// Should not be used after Step(), Fork(), or Log() is called.
+// Should not be used after Step(), Fork(), or Logger() is called.
 func (sub *Sub) PrefillZZZ(k string, v zzz) *Sub {
 	sub.settings.PrefillZZZ(k, v)
 	return sub

--- a/tools/xopzzz/xopzzz.go
+++ b/tools/xopzzz/xopzzz.go
@@ -252,6 +252,7 @@ var macros = map[string]map[string]string{
 		"Trace": "",
 		"Debug": "",
 		"Info":  "",
+		"Log":   "",
 		"Warn":  "",
 		"Error": "",
 		"Alert": "",

--- a/xopbase/base.go
+++ b/xopbase/base.go
@@ -61,7 +61,7 @@ type Logger interface {
 
 	// ReferencesKept should return true if Any() objects are not immediately
 	// serialized (the object is kept around and serilized later).  If copies
-	// are kept, then xop.Log will make copies.
+	// are kept, then xop.Logger will make copies.
 	ReferencesKept() bool
 
 	// Buffered should return true if the logger buffers output and sends

--- a/xopbase/base.zzzgo
+++ b/xopbase/base.zzzgo
@@ -58,7 +58,7 @@ type Logger interface {
 
 	// ReferencesKept should return true if Any() objects are not immediately
 	// serialized (the object is kept around and serilized later).  If copies
-	// are kept, then xop.Log will make copies.
+	// are kept, then xop.Logger will make copies.
 	ReferencesKept() bool
 
 	// Buffered should return true if the logger buffers output and sends

--- a/xopconsole/replay.go
+++ b/xopconsole/replay.go
@@ -1042,6 +1042,11 @@ func Replay(ctx context.Context, inputStream io.Reader, dest xopbase.Logger) err
 				replayData: x,
 				level:      xopnum.InfoLevel,
 			}.replayLine(ctx, t)
+		case "log":
+			err = replayLine{
+				replayData: x,
+				level:      xopnum.LogLevel,
+			}.replayLine(ctx, t)
 		case "trace":
 			err = replayLine{
 				replayData: x,

--- a/xopmiddle/middleware.go
+++ b/xopmiddle/middleware.go
@@ -43,10 +43,10 @@ func (i Inbound) HandlerMiddleware() func(http.Handler) http.Handler {
 }
 
 // InjectorWithContext is compatible with https://github.com/muir/nject/nvelope and
-// provides a *xop.Log to the injection chain.  It also puts the log in
+// provides a *xop.Logger to the injection chain.  It also puts the log in
 // the request context.
-func (i Inbound) InjectorWithContext() func(inner func(*xop.Log, *http.Request), w http.ResponseWriter, r *http.Request) {
-	return func(inner func(*xop.Log, *http.Request), w http.ResponseWriter, r *http.Request) {
+func (i Inbound) InjectorWithContext() func(inner func(*xop.Logger, *http.Request), w http.ResponseWriter, r *http.Request) {
+	return func(inner func(*xop.Logger, *http.Request), w http.ResponseWriter, r *http.Request) {
 		log, ctx := i.makeChildSpan(w, r)
 		defer log.Done()
 		r = r.WithContext(log.IntoContext(ctx))
@@ -55,16 +55,16 @@ func (i Inbound) InjectorWithContext() func(inner func(*xop.Log, *http.Request),
 }
 
 // InjectorWithContext is compatible with https://github.com/muir/nject/nvelope and
-// provides a *xop.Log to the injection chain.
-func (i Inbound) Injector() func(inner func(*xop.Log), w http.ResponseWriter, r *http.Request) {
-	return func(inner func(*xop.Log), w http.ResponseWriter, r *http.Request) {
+// provides a *xop.Logger to the injection chain.
+func (i Inbound) Injector() func(inner func(*xop.Logger), w http.ResponseWriter, r *http.Request) {
+	return func(inner func(*xop.Logger), w http.ResponseWriter, r *http.Request) {
 		log, _ := i.makeChildSpan(w, r)
 		defer log.Done()
 		inner(log)
 	}
 }
 
-func (i Inbound) makeChildSpan(w http.ResponseWriter, r *http.Request) (*xop.Log, context.Context) {
+func (i Inbound) makeChildSpan(w http.ResponseWriter, r *http.Request) (*xop.Logger, context.Context) {
 	name := i.requestToName(r)
 	if name == "" {
 		name = r.URL.String()

--- a/xopmiddle/middleware_test.go
+++ b/xopmiddle/middleware_test.go
@@ -142,7 +142,7 @@ var injectMethods = []struct {
 		name: "injector",
 		f: func(t *testing.T, inbound xopmiddle.Inbound, w http.ResponseWriter, r *http.Request) {
 			var called bool
-			inbound.Injector()(func(log *xop.Log) {
+			inbound.Injector()(func(log *xop.Logger) {
 				assert.NotNil(t, log, "log set")
 				called = true
 			}, w, r)
@@ -153,7 +153,7 @@ var injectMethods = []struct {
 		name: "injector with context",
 		f: func(t *testing.T, inbound xopmiddle.Inbound, w http.ResponseWriter, r *http.Request) {
 			var called bool
-			inbound.InjectorWithContext()(func(log *xop.Log, r *http.Request) {
+			inbound.InjectorWithContext()(func(log *xop.Logger, r *http.Request) {
 				_ = xop.FromContextOrPanic(r.Context())
 				assert.NotNil(t, log, "log set")
 				called = true

--- a/xopnum/level.go
+++ b/xopnum/level.go
@@ -10,11 +10,19 @@ const (
 	// https://github.com/open-telemetry/opentelemetry-proto/blob/main/opentelemetry/proto/logs/v1/logs.proto
 	// Most of the levels correspond to OTEl's levels, but
 	//   TraceLevel is OTEL's "Trace2"
+	//   DebugLevel is OTEL's "Debug3"
+	//   LogLevel is OTEL's "Info"
+	//   InfoLevel is OTEL's "Info3"
+	//   WarnLevel is OTEL's "Warn"
+	//   ErrorLevel is OTEL's "Error"
 	//   AlertLevel is OTEL's "Error4"
-	// There is no fatal level.
+	// At this time, there is no fatal level in XOP.
+	//
+	// LogLevel is the expected default level to use for most logs.
 	TraceLevel Level = 2  // trace
-	DebugLevel Level = 5  // debug
-	InfoLevel  Level = 9  // info
+	DebugLevel Level = 7  // debug
+	LogLevel   Level = 9  // log
+	InfoLevel  Level = 11 // info
 	WarnLevel  Level = 13 // warn
 	ErrorLevel Level = 17 // error
 	AlertLevel Level = 20 // alert

--- a/xopnum/level_enumer.go
+++ b/xopnum/level_enumer.go
@@ -14,39 +14,44 @@ const (
 	_LevelLowerName_0 = "trace"
 	_LevelName_1      = "debug"
 	_LevelLowerName_1 = "debug"
-	_LevelName_2      = "info"
-	_LevelLowerName_2 = "info"
-	_LevelName_3      = "warn"
-	_LevelLowerName_3 = "warn"
-	_LevelName_4      = "error"
-	_LevelLowerName_4 = "error"
-	_LevelName_5      = "alert"
-	_LevelLowerName_5 = "alert"
+	_LevelName_2      = "log"
+	_LevelLowerName_2 = "log"
+	_LevelName_3      = "info"
+	_LevelLowerName_3 = "info"
+	_LevelName_4      = "warn"
+	_LevelLowerName_4 = "warn"
+	_LevelName_5      = "error"
+	_LevelLowerName_5 = "error"
+	_LevelName_6      = "alert"
+	_LevelLowerName_6 = "alert"
 )
 
 var (
 	_LevelIndex_0 = [...]uint8{0, 5}
 	_LevelIndex_1 = [...]uint8{0, 5}
-	_LevelIndex_2 = [...]uint8{0, 4}
+	_LevelIndex_2 = [...]uint8{0, 3}
 	_LevelIndex_3 = [...]uint8{0, 4}
-	_LevelIndex_4 = [...]uint8{0, 5}
+	_LevelIndex_4 = [...]uint8{0, 4}
 	_LevelIndex_5 = [...]uint8{0, 5}
+	_LevelIndex_6 = [...]uint8{0, 5}
 )
 
 func (i Level) String() string {
 	switch {
 	case i == 2:
 		return _LevelName_0
-	case i == 5:
+	case i == 7:
 		return _LevelName_1
 	case i == 9:
 		return _LevelName_2
-	case i == 13:
+	case i == 11:
 		return _LevelName_3
-	case i == 17:
+	case i == 13:
 		return _LevelName_4
-	case i == 20:
+	case i == 17:
 		return _LevelName_5
+	case i == 20:
+		return _LevelName_6
 	default:
 		return fmt.Sprintf("Level(%d)", i)
 	}
@@ -57,37 +62,41 @@ func (i Level) String() string {
 func _LevelNoOp() {
 	var x [1]struct{}
 	_ = x[TraceLevel-(2)]
-	_ = x[DebugLevel-(5)]
-	_ = x[InfoLevel-(9)]
+	_ = x[DebugLevel-(7)]
+	_ = x[LogLevel-(9)]
+	_ = x[InfoLevel-(11)]
 	_ = x[WarnLevel-(13)]
 	_ = x[ErrorLevel-(17)]
 	_ = x[AlertLevel-(20)]
 }
 
-var _LevelValues = []Level{TraceLevel, DebugLevel, InfoLevel, WarnLevel, ErrorLevel, AlertLevel}
+var _LevelValues = []Level{TraceLevel, DebugLevel, LogLevel, InfoLevel, WarnLevel, ErrorLevel, AlertLevel}
 
 var _LevelNameToValueMap = map[string]Level{
 	_LevelName_0[0:5]:      TraceLevel,
 	_LevelLowerName_0[0:5]: TraceLevel,
 	_LevelName_1[0:5]:      DebugLevel,
 	_LevelLowerName_1[0:5]: DebugLevel,
-	_LevelName_2[0:4]:      InfoLevel,
-	_LevelLowerName_2[0:4]: InfoLevel,
-	_LevelName_3[0:4]:      WarnLevel,
-	_LevelLowerName_3[0:4]: WarnLevel,
-	_LevelName_4[0:5]:      ErrorLevel,
-	_LevelLowerName_4[0:5]: ErrorLevel,
-	_LevelName_5[0:5]:      AlertLevel,
-	_LevelLowerName_5[0:5]: AlertLevel,
+	_LevelName_2[0:3]:      LogLevel,
+	_LevelLowerName_2[0:3]: LogLevel,
+	_LevelName_3[0:4]:      InfoLevel,
+	_LevelLowerName_3[0:4]: InfoLevel,
+	_LevelName_4[0:4]:      WarnLevel,
+	_LevelLowerName_4[0:4]: WarnLevel,
+	_LevelName_5[0:5]:      ErrorLevel,
+	_LevelLowerName_5[0:5]: ErrorLevel,
+	_LevelName_6[0:5]:      AlertLevel,
+	_LevelLowerName_6[0:5]: AlertLevel,
 }
 
 var _LevelNames = []string{
 	_LevelName_0[0:5],
 	_LevelName_1[0:5],
-	_LevelName_2[0:4],
+	_LevelName_2[0:3],
 	_LevelName_3[0:4],
-	_LevelName_4[0:5],
+	_LevelName_4[0:4],
 	_LevelName_5[0:5],
+	_LevelName_6[0:5],
 }
 
 // LevelString retrieves an enum value from the enum constants string name.

--- a/xopotel/doc.go
+++ b/xopotel/doc.go
@@ -37,7 +37,7 @@ creation to Open Telemetry.
 
 If you don't have access to a TracerProvider at all and instead have
 a "go.opentelemetry.io/otel/trace".Span, you can use that as the basis for generating
-logs with XOP by converting it directly to a *xop.Log.
+logs with XOP by converting it directly to a *xop.Logger.
 
 # BufferedReplayLogger
 

--- a/xopotel/otel.go
+++ b/xopotel/otel.go
@@ -34,7 +34,7 @@ func xopTraceFromSpan(span oteltrace.Span) xoptrace.Trace {
 
 // SpanToLog allows xop to add logs to an existing OTEL span.  log.Done() will be
 // ignored for this span.
-func SpanToLog(ctx context.Context, name string, extraModifiers ...xop.SeedModifier) *xop.Log {
+func SpanToLog(ctx context.Context, name string, extraModifiers ...xop.SeedModifier) *xop.Logger {
 	span := oteltrace.SpanFromContext(ctx)
 	xoptrace := xopTraceFromSpan(span)
 	tracer := span.TracerProvider().Tracer("xoputil")

--- a/xopotel/otel.zzzgo
+++ b/xopotel/otel.zzzgo
@@ -34,7 +34,7 @@ func xopTraceFromSpan(span oteltrace.Span) xoptrace.Trace {
 
 // SpanToLog allows xop to add logs to an existing OTEL span.  log.Done() will be
 // ignored for this span.
-func SpanToLog(ctx context.Context, name string, extraModifiers ...xop.SeedModifier) *xop.Log {
+func SpanToLog(ctx context.Context, name string, extraModifiers ...xop.SeedModifier) *xop.Logger {
 	span := oteltrace.SpanFromContext(ctx)
 	xoptrace := xopTraceFromSpan(span)
 	tracer := span.TracerProvider().Tracer("xoputil")

--- a/xoprecorder/recorder_test.go
+++ b/xoprecorder/recorder_test.go
@@ -24,6 +24,7 @@ func TestRecorderLogMethods(t *testing.T) {
 	log.Info().Msg("basic info message")
 	log.Error().Msg("basic error message")
 	log.Alert().Msg("basic alert message")
+	log.Log().Msg("basic log message")
 	log.Debug().Msg("basic debug message")
 	log.Trace().Msg("basic trace message")
 	log.Info().String("foo", "bar").Int("num", 38).Template("a test {foo} with {num}")
@@ -35,7 +36,7 @@ func TestRecorderLogMethods(t *testing.T) {
 	}
 	f := log.Sub().Fork("forkie")
 	f.Span().Int(xopconst.HTTPStatusCode, 204)
-	assert.Empty(t, rLog.FindLines(xoprecorder.MessageEquals("basic trace message")), "debug filtered out by log level")
+	assert.Empty(t, rLog.FindLines(xoprecorder.MessageEquals("basic trace message")), "trace filtered out by log level")
 	assert.Equal(t, 1, rLog.CountLines(xoprecorder.MessageEquals("basic alert message")), "count alert")
 	assert.Equal(t, 1, rLog.CountLines(xoprecorder.TextContains("a test")), "count a test")
 	assert.Equal(t, 1, rLog.CountLines(xoprecorder.TextContains("a test bar")), "count a test foo")

--- a/xopresty/resty.go
+++ b/xopresty/resty.go
@@ -42,7 +42,7 @@ import (
 var _ resty.Logger = restyLogger{}
 
 type restyLogger struct {
-	log *xop.Log
+	log *xop.Logger
 }
 
 func (rl restyLogger) Errorf(format string, v ...interface{}) { rl.log.Error().Msgf(format, v...) }
@@ -61,7 +61,7 @@ type contextValue struct {
 	b3Sent            bool
 	b3Trace           xoptrace.Trace
 	response          bool
-	log               *xop.Log
+	log               *xop.Logger
 	retryCount        int
 	originalStartTime time.Time
 }
@@ -87,7 +87,7 @@ func WithNameGenerate(f func(*resty.Request) string) ClientOpt {
 // ExtraLogging should only be called once but if another resty
 // callback panic's, it is possible ExtraLogging will be called
 // twice.
-type ExtraLogging func(log *xop.Log, originalStartTime time.Time, retryCount int, request *resty.Request, response *resty.Response, err error)
+type ExtraLogging func(log *xop.Logger, originalStartTime time.Time, retryCount int, request *resty.Request, response *resty.Response, err error)
 
 func WithExtraLogging(f ExtraLogging) ClientOpt {
 	return func(config *config) {
@@ -111,7 +111,7 @@ func Client(client *resty.Client, opts ...ClientOpt) *resty.Client {
 			}
 			return r.Method + " " + url
 		},
-		extraLogging: func(log *xop.Log, originalStartTime time.Time, retryCount int, request *resty.Request, response *resty.Response, err error) {
+		extraLogging: func(log *xop.Logger, originalStartTime time.Time, retryCount int, request *resty.Request, response *resty.Response, err error) {
 		},
 	}
 	for _, f := range opts {

--- a/xopresty/resty_test.go
+++ b/xopresty/resty_test.go
@@ -33,7 +33,7 @@ var cases = []struct {
 	name         string
 	clientMod    func(*resty.Client) *resty.Client
 	requestMod   func(*resty.Request) *resty.Request
-	handler      func(t *testing.T, log *xop.Log, w http.ResponseWriter, r *http.Request)
+	handler      func(t *testing.T, log *xop.Logger, w http.ResponseWriter, r *http.Request)
 	restyOpts    []xopresty.ClientOpt
 	expectError  bool
 	expectedText []string
@@ -62,7 +62,7 @@ var cases = []struct {
 				SetHeader("Content-Type", "application/json").
 				SetHeader("Accept", "application/json")
 		},
-		handler: func(t *testing.T, log *xop.Log, w http.ResponseWriter, r *http.Request) {
+		handler: func(t *testing.T, log *xop.Logger, w http.ResponseWriter, r *http.Request) {
 			enc, err := json.Marshal(exampleResult{
 				Score:   3.8,
 				Comment: "good progress",
@@ -87,7 +87,7 @@ func TestXopResty(t *testing.T) {
 			seed := xop.NewSeed(xop.WithBase(tLog))
 			log := seed.Request("client")
 			log.Info().Msg("i am the base log")
-			ctx := log.Sub().MinLevel(xopnum.TraceLevel).Log().IntoContext(context.Background())
+			ctx := log.Sub().MinLevel(xopnum.TraceLevel).Logger().IntoContext(context.Background())
 
 			var called bool
 			inbound := xopmiddle.New(seed, func(r *http.Request) string {

--- a/xoptest/testlogger.go
+++ b/xoptest/testlogger.go
@@ -61,7 +61,7 @@ func New(t testingT) *Logger {
 	}
 }
 
-func (log *Logger) Log() *xop.Log {
+func (log *Logger) Logger() *xop.Logger {
 	return xop.NewSeed(xop.WithBase(log)).Request(log.t.Name())
 }
 

--- a/xoptest/testlogger_test.go
+++ b/xoptest/testlogger_test.go
@@ -18,18 +18,19 @@ import (
 func TestLogMethods(t *testing.T) {
 	start := time.Now()
 	tLog := xoptest.New(t)
-	log := tLog.Log()
+	log := tLog.Logger()
 	log.Info().Msg("basic info message")
 	log.Error().Msg("basic error message")
 	log.Alert().Msg("basic alert message")
+	log.Log().Msg("basic log message")
 	log.Debug().Msg("basic debug message")
 	log.Trace().Msg("basic trace message")
 	log.Info().String("foo", "bar").Int("num", 38).Template("a test {foo} with {num}")
-	lines := tLog.Recorder().FindLines(xoprecorder.MessageEquals("basic debug message"))
+	lines := tLog.Recorder().FindLines(xoprecorder.MessageEquals("basic log message"))
 	if assert.NotEmpty(t, lines, "found some") {
 		assert.True(t, !lines[0].Timestamp.Before(start), "time seq")
-		assert.Equal(t, "basic debug message", lines[0].Message, "message")
-		assert.Equal(t, xopnum.DebugLevel, lines[0].Level, "level")
+		assert.Equal(t, "basic log message", lines[0].Message, "message")
+		assert.Equal(t, xopnum.LogLevel, lines[0].Level, "level")
 	}
 	f := log.Sub().Fork("forkie")
 	f.Span().Int(xopconst.HTTPStatusCode, 204)
@@ -53,7 +54,7 @@ func TestReplayTextLogger(t *testing.T) {
 		mc := mc
 		t.Run(mc.Name, func(t *testing.T) {
 			tLog := xoptest.New(t)
-			log := tLog.Log()
+			log := tLog.Logger()
 			if len(mc.SeedMods) != 0 {
 				t.Logf("Applying %d extra seed mods", len(mc.SeedMods))
 				log = log.Span().SubSeed(mc.SeedMods...).Request(t.Name())

--- a/xoptest/xoptestutil/cases.go
+++ b/xoptest/xoptestutil/cases.go
@@ -20,13 +20,13 @@ const NeedsEscaping = `"\<'` + "\n\r\t\b\x00"
 var MessageCases = []struct {
 	Name         string
 	ExtraFlushes int
-	Do           func(t *testing.T, log *xop.Log, tlog *xoptest.Logger)
+	Do           func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger)
 	SkipOTEL     bool
 	SeedMods     []xop.SeedModifier
 }{
 	{
 		Name: "one-span",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			log.Info().Msg("basic info message")
 			log.Error().Msg("basic error message")
 			log.Alert().Msg("basic alert message")
@@ -52,7 +52,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-singles-in-request",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			log.Span().Bool(ExampleMetadataSingleBool, false)
 			log.Span().Bool(ExampleMetadataSingleBool, true)
 			log.Span().Bool(ExampleMetadataLockedBool, true)
@@ -83,7 +83,7 @@ var MessageCases = []struct {
 	{
 		Name:     "metadata-traces",
 		SkipOTEL: true,
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			s2 := log.Sub().Fork("S2")
 			s3 := s2.Sub().Fork("S3")
 			log.Span().Link(ExampleMetadataSingleLink, s2.Span().Bundle().Trace)
@@ -102,7 +102,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-float64",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			log.Span().Float64(ExampleMetadataSingleFloat64, 40.3)
 			log.Span().Float64(ExampleMetadataSingleFloat64, 40.4)
 			log.Span().Float64(ExampleMetadataLockedFloat64, 30.5)
@@ -119,7 +119,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-time",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			t1 := time.Now().Round(time.Second)
 			t2 := t1.Add(time.Minute)
 			log.Span().Time(ExampleMetadataSingleTime, t1)
@@ -138,7 +138,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-duration",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			d1 := time.Millisecond
 			d2 := time.Millisecond * 5
 			log.Span().Duration(ExampleMetadataSingleDuration, d1)
@@ -157,7 +157,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-singles-in-span",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			ss := log.Sub().Fork("spoon")
 			ss.Span().Bool(ExampleMetadataSingleBool, false)
 			ss.Span().Bool(ExampleMetadataSingleBool, true)
@@ -210,7 +210,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-any",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			ss := log.Sub().Fork("knife")
 			a := map[string]interface{}{
 				"foo":   "bar",
@@ -246,7 +246,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-iota-enum",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			ss := log.Sub().Step("stool")
 			ss.Span().EmbeddedEnum(SingleEnumTwo)
 			ss.Span().EmbeddedEnum(SingleEnumTwo)
@@ -266,7 +266,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-embedded-enum",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			ss := log.Sub().Step("stool")
 			ss.Span().EmbeddedEnum(SingleEEnumTwo)
 			ss.Span().EmbeddedEnum(SingleEEnumTwo)
@@ -286,7 +286,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-enum",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			ss := log.Sub().Step("stool")
 			ss.Span().Enum(ExampleMetadataSingleXEnum, xopconst.SpanKindServer)
 			ss.Span().Enum(ExampleMetadataSingleXEnum, xopconst.SpanKindClient)
@@ -306,7 +306,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-multiples",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			// ss := log.Sub().Fork("a fork metadata multiples")
 			log.Span().Bool(ExampleMetadataMultipleBool, true)
 			log.Span().Bool(ExampleMetadataMultipleBool, true)
@@ -319,7 +319,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "metadata-distinct",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			// ss := log.Sub().Fork("a fork metadata distinct")
 			log.Span().Bool(ExampleMetadataDistinctBool, true)
 			log.Span().Bool(ExampleMetadataDistinctBool, true)
@@ -342,7 +342,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "one-done",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			_ = log.Sub().Fork("a fork one done")
 			MicroNap()
 			log.Done()
@@ -350,8 +350,8 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "prefill",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
-			p := log.Sub().PrefillFloat64("f", 23).PrefillText("pre!").Log()
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
+			p := log.Sub().PrefillFloat64("f", 23).PrefillText("pre!").Logger()
 			p.Error().Int16("i16", int16(7)).Msg("pf")
 			log.Alert().Int32("i32", int32(77)).Msgf("pf %s", "bar")
 			MicroNap()
@@ -361,7 +361,7 @@ var MessageCases = []struct {
 	{
 		Name:         "manipulate-seed",
 		ExtraFlushes: 1,
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			l2 := log.Span().SubSeed().Request("L2")
 			l2.Info().Msg("in the new log")
 			MicroNap()
@@ -372,7 +372,7 @@ var MessageCases = []struct {
 	{
 		Name:         "add-and-remove-loggers-with-a-seed",
 		ExtraFlushes: 2,
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			tlog2 := xoptest.New(t)
 			r2 := log.Span().SubSeed(xop.WithBase(tlog2)).Request("R2")
 			r3 := r2.Span().SubSeed(xop.WithoutBase(tlog2)).Request("R3")
@@ -386,7 +386,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "add-and-remove-loggers-with-a-span",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			tlog2 := xoptest.New(t)
 			s2 := log.Sub().Step("S2", xop.WithBase(tlog2))
 			s3 := s2.Sub().Detach().Fork("S3", xop.WithoutBase(tlog2))
@@ -402,18 +402,18 @@ var MessageCases = []struct {
 		Name:         "log-after-done",
 		ExtraFlushes: 1,
 		SkipOTEL:     true,
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			s2 := log.Sub().Step("S2")
 			s2.Info().Int8("i8", 9).Msg("a line before done")
 			MicroNap()
 			s2.Done()
-			assert.Empty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("XOP: log was already done, but was used again")), "no err")
+			assert.Empty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("XOP: logger was already done, but was used again")), "no err")
 			s2.Info().Int16("i16", 940).Msg("a post-done line, should trigger an error log")
-			assert.NotEmpty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("XOP: log was already done, but was used again")), "no err")
-			assert.Empty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("called on log object when it was already Done")), "no err")
+			assert.NotEmpty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("XOP: logger was already done, but was used again")), "no err")
+			assert.Empty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("called on logger object when it was already Done")), "no err")
 			MicroNap()
 			s2.Done()
-			assert.NotEmpty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("called on log object when it was already Done")), "now err")
+			assert.NotEmpty(t, tlog.Recorder().FindLines(xoprecorder.TextContains("called on logger object when it was already Done")), "now err")
 			log.Flush()
 			s2.Warn().Int32("i32", 940940).Msg("another post-done line, should trigger an error log")
 			MicroNap()
@@ -422,7 +422,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "lots-of-types",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			p := log.Sub().PrefillInt("pfint", 439).PrefillInt8("pfint8", 82).PrefillInt16("pfint16", 829).
 				PrefillInt32("pfint32", 4328).PrefillInt64("pfint64", -2382).
 				PrefillUint("pfuint", 439).PrefillUint8("pfuint8", 82).PrefillUint16("pfuint16", 829).
@@ -435,7 +435,7 @@ var MessageCases = []struct {
 				PrefillAny("pfanyhow", map[string]interface{}{"x": "y", "z": 19}).
 				PrefillEnum(ExampleMetadataMultipleXEnum, xopconst.SpanKindClient).
 				PrefillEmbeddedEnum(LockedEEnumTwo).
-				Log()
+				Logger()
 			log.Warn().Int("int", 439).Int8("int8", 82).Int16("int16", 829).
 				Int32("int32", 4328).Int64("int64", -2382).
 				Uint("uint", 439).Uint8("uint8", 82).Uint16("uint16", 829).
@@ -456,8 +456,8 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "type-time",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
-			p := log.Sub().PrefillTime("-1m", time.Now().Add(-time.Minute).Round(time.Millisecond)).Log()
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
+			p := log.Sub().PrefillTime("-1m", time.Now().Add(-time.Minute).Round(time.Millisecond)).Logger()
 			p.Warn().Time("now", time.Now().Round(time.Millisecond)).Msgs("time!")
 			MicroNap()
 			log.Done()
@@ -465,8 +465,8 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "type-duration",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
-			p := log.Sub().PrefillDuration("1m", time.Minute).Log()
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
+			p := log.Sub().PrefillDuration("1m", time.Minute).Logger()
 			p.Warn().Duration("hour", time.Hour).Msg("duration")
 			MicroNap()
 			log.Done()
@@ -474,7 +474,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "type-link",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			log.Warn().Link(log.Span().Bundle().Trace, "me, again")
 			MicroNap()
 			log.Done()
@@ -482,7 +482,7 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "type-model",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			log.Warn().Model(map[string]interface{}{"x": "y", "z": 19}, "some stuff")
 			MicroNap()
 			log.Done()
@@ -490,8 +490,8 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "type-error",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
-			p := log.Sub().PrefillError("question", fmt.Errorf("why would you pre-fill an error?")).Log()
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
+			p := log.Sub().PrefillError("question", fmt.Errorf("why would you pre-fill an error?")).Logger()
 			p.Warn().Error("answer", fmt.Errorf("I don't know, why would you prefill an error")).Msgs(time.Now())
 			MicroNap()
 			log.Done()
@@ -499,27 +499,28 @@ var MessageCases = []struct {
 	},
 	{
 		Name: "log-levels",
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			var callCount int
 			sc := newStringCounter(&callCount, "foobar")
-			skipper := log.Sub().MinLevel(xopnum.InfoLevel).Log()
+			skipper := log.Sub().MinLevel(xopnum.InfoLevel).Logger()
 			skipper.Debug().
 				Stringer("avoid", sc).
 				String("avoid", "blaf").
 				Any("null", nil).
 				Error("no", fmt.Errorf("bar")).
 				Msg("no foobar")
-			log.Trace().Stringer("don't", sc).Msg("yes, foobar")
-			log.Debug().Stringer("do", sc).Msg("yes, foobar")
-			assert.Equal(t, 1, callCount, "stringer called once")
-			noSkip := log.Sub().MinLevel(xopnum.DebugLevel).Log()
+			log.Trace().Stringer("don't", sc).Msg("yes, trace")
+			log.Debug().Stringer("do", sc).Msg("yes, debug")
+			log.Log().Stringer("do", sc).Msg("yes, log")
+			assert.Equal(t, 2, callCount, "stringer called twice")
+			noSkip := log.Sub().MinLevel(xopnum.DebugLevel).Logger()
 			noSkip.Debug().
 				Stringer("stringer", sc).
 				String("string", "blaf").
 				Any("null", nil).
 				Error("yes", fmt.Errorf("blaf")).
 				Msg("yes foobar")
-			assert.Equal(t, 2, callCount, "stringer called twice")
+			assert.Equal(t, 3, callCount, "stringer called thrice")
 			MicroNap()
 			log.Done()
 		},
@@ -539,7 +540,7 @@ var MessageCases = []struct {
 				return bundle
 			}()),
 		},
-		Do: func(t *testing.T, log *xop.Log, tlog *xoptest.Logger) {
+		Do: func(t *testing.T, log *xop.Logger, tlog *xoptest.Logger) {
 			assert.Equal(t, "00-a60a3cc0123a043fee48839c9d52a645-c63f9d81e2285f34-01", log.Span().Bundle().Parent.String(), "trace parent")
 			assert.Equal(t, "a60a3cc0123a043fee48839c9d52a645", log.Span().Bundle().Trace.GetTraceID().String(), "trace trace")
 			assert.NotEqual(t, "c63f9d81e2285f34", log.Span().Bundle().Trace.GetSpanID().String(), "trace trace")

--- a/xoptest/xoptestutil/contextlevel_test.go
+++ b/xoptest/xoptestutil/contextlevel_test.go
@@ -81,11 +81,11 @@ func TestAdjusterLevel(t *testing.T) {
 
 type foo []xop.AdjusterOption
 
-func (f foo) Context() func(context.Context) *xop.Log {
+func (f foo) Context() func(context.Context) *xop.Logger {
 	return xop.ContextLevelAdjuster(xop.FromContextOrDefault, f...)
 }
 
-func (f foo) Logger() func(*xop.Log) *xop.Log {
+func (f foo) Logger() func(*xop.Logger) *xop.Logger {
 	return xop.LevelAdjuster(f...)
 }
 


### PR DESCRIPTION
The expectation is that the new "Log" level will be the default level people use.  

Adding "Log()" as a level, created a conflict with the "Log()" that is used to create loggers, so the top-level logger changed from "Log" to "Logger". 

That creates a name conflict that is not resolved with xopbase.Logger, the lower level logger ("exporter" in OTEL vocab).
